### PR TITLE
Fix SSR document check in Vue components

### DIFF
--- a/docs/.vitepress/components/About.vue
+++ b/docs/.vitepress/components/About.vue
@@ -9,6 +9,9 @@ import { computed } from 'vue'
 import data from '../../data'
 import enData from '../../en-data'
 
-const lang = document.documentElement.lang === 'en-US' ? 'en' : 'zh'
+const lang = typeof document !== 'undefined' &&
+  document.documentElement.lang === 'en-US'
+  ? 'en'
+  : 'zh'
 const about = computed(() => lang === 'en' ? enData.introduce.about : data.introduce.about)
 </script>

--- a/docs/.vitepress/components/Educations.vue
+++ b/docs/.vitepress/components/Educations.vue
@@ -15,7 +15,10 @@ import { computed } from 'vue'
 import data from '../../data'
 import enData from '../../en-data'
 
-const lang = document.documentElement.lang === 'en-US' ? 'en' : 'zh'
+const lang = typeof document !== 'undefined' &&
+  document.documentElement.lang === 'en-US'
+  ? 'en'
+  : 'zh'
 const edu = computed(() => lang === 'en' ? enData.educations : data.educations)
 const title = lang === 'en' ? 'Education' : '學歷'
 </script>

--- a/docs/.vitepress/components/Experiences.vue
+++ b/docs/.vitepress/components/Experiences.vue
@@ -34,7 +34,10 @@ import data from '../../data'
 import enData from '../../en-data'
 import Tag from './Tag.vue'
 
-const lang = document.documentElement.lang === 'en-US' ? 'en' : 'zh'
+const lang = typeof document !== 'undefined' &&
+  document.documentElement.lang === 'en-US'
+  ? 'en'
+  : 'zh'
 const exps = computed(() => lang === 'en' ? enData.experiences : data.experiences)
 const title = lang === 'en' ? 'Work Experience' : '工作經歷'
 </script>

--- a/docs/.vitepress/components/MySkillList.vue
+++ b/docs/.vitepress/components/MySkillList.vue
@@ -10,7 +10,11 @@ import data from '../../data'
 import enData from '../../en-data'
 import Tag from './Tag.vue'
 
-const lang = computed(() => document.documentElement.lang === 'en-US' ? 'en' : 'zh')
+const lang = computed(() =>
+  typeof document !== 'undefined' && document.documentElement.lang === 'en-US'
+    ? 'en'
+    : 'zh'
+)
 const skills = computed(() => lang.value === 'en' ? enData.skills : data.skills)
 const title = computed(() => lang.value === 'en' ? 'Skills' : '技能關鍵字')
 </script>

--- a/docs/.vitepress/components/Projects.vue
+++ b/docs/.vitepress/components/Projects.vue
@@ -21,7 +21,10 @@ import data from '../../data'
 import enData from '../../en-data'
 import Tag from './Tag.vue'
 
-const lang = document.documentElement.lang === 'en-US' ? 'en' : 'zh'
+const lang = typeof document !== 'undefined' &&
+  document.documentElement.lang === 'en-US'
+  ? 'en'
+  : 'zh'
 const pro = computed(() => lang === 'en' ? enData.projects : data.projects)
 const title = lang === 'en' ? 'Projects' : '專案'
 </script>


### PR DESCRIPTION
## Summary
- handle server-side rendering for language detection in resume components
- use `typeof document !== 'undefined'` checks to avoid `document` errors during build

## Testing
- `npm run docs:build` *(fails: vitepress not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe230e52883228065792a7b8f9f1e